### PR TITLE
Fix reduce closure for Swift 4

### DIFF
--- a/Source/JSONJoy.swift
+++ b/Source/JSONJoy.swift
@@ -66,7 +66,7 @@ open class JSONLoader {
      */
     public func get<T: JSONJoy>() throws -> [T] {
         guard let a = getOptionalArray() else { throw JSONError.wrongType }
-        return try a.reduce([T]()) { $0.0 + [try T($0.1)] }
+        return try a.reduce([T]()) { $0 + [try T($1)] }
     }
     
     /**
@@ -74,7 +74,7 @@ open class JSONLoader {
      */
     open func get<T: JSONBasicType>() throws -> [T] {
         guard let a = getOptionalArray() else { throw JSONError.wrongType }
-        return try a.reduce([T]()) { $0.0 + [try $0.1.get()] }
+        return try a.reduce([T]()) { $0 + [try $1.get()] }
     }
     
     /**
@@ -108,7 +108,7 @@ open class JSONLoader {
      */
     public func getOptional<T: JSONJoy>() -> [T]? {
         guard let a = getOptionalArray() else { return nil }
-        do { return try a.reduce([T]()) { $0.0 + [try T($0.1)] } }
+        do { return try a.reduce([T]()) { $0 + [try T($1)] } }
         catch { return nil }
     }
     
@@ -117,7 +117,7 @@ open class JSONLoader {
      */
     public func getOptional<T: JSONBasicType>() -> [T]? {
         guard let a = getOptionalArray() else { return nil }
-        do { return try a.reduce([T]()) { $0.0 + [try $0.1.get()] } }
+        do { return try a.reduce([T]()) { $0 + [try $1.get()] } }
         catch { return nil }
     }
     


### PR DESCRIPTION
Hello, 

In Swift 3, you could use one parameter in the closure which could be inferred as a Tuple or two parameters which could be  inferred as the Tuple's elements.
It is not possible anymore in Swift 4.

For more explanation: [https://github.com/apple/swift-evolution/blob/master/proposals/0110-distingish-single-tuple-arg.md](https://github.com/apple/swift-evolution/blob/master/proposals/0110-distingish-single-tuple-arg.md)